### PR TITLE
Deduplicate "with" by shortening Exists Op Desc

### DIFF
--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -30,7 +30,7 @@ agg_op_str_dict = {
     MinAggregationOp: " the minimum <{}> in all related records",
     MajorityAggregationOp: " the majority <{}> in all related records",
     CountAggregationOp: "the number of records",
-    ExistsAggregationOp: "if there exists a record with",
+    ExistsAggregationOp: "if there exists a record",
 }
 
 filter_op_str_dict = {

--- a/trane/ops/aggregation_ops.py
+++ b/trane/ops/aggregation_ops.py
@@ -101,7 +101,7 @@ class MajorityAggregationOp(AggregationOpBase):
 
 class ExistsAggregationOp(AggregationOpBase):
     input_output_types = [("None", "Boolean")]
-    description = " if there exists a record with"
+    description = " if there exists a record"
 
     def label_function(self, dataslice):
         return len(dataslice) > 0


### PR DESCRIPTION
"with" in the ExistsAggregationOp was causing duplication of with in the sentence since the filter operation starts with "with"