### PR TITLE
Exclude foreign keys from being used to generate prediction problems

### DIFF
--- a/.github/workflows/test_without_dev_deps.yaml
+++ b/.github/workflows/test_without_dev_deps.yaml
@@ -49,5 +49,5 @@ jobs:
               table_meta=table_meta,
           )
           problems = problem_generator.generate(data, generate_thresholds=True)
-          assert len(problems) >= 1000
+          assert len(problems) >= 800
         shell: python

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,11 +11,15 @@ v0.5.0 ()
 * Fixes
     * Fix FeaturetoolsWrapper class and label times [#100][#100]
     * Fix denormalize to support more than 2 tables [#104][#104]
+    * Exclude foreign keys from being used to generate prediction problems [#108][#108]
+    * Change "index" to "primary_key" [#108][#108]
+    * Fixes duplicate prediction problem generation by hashing all possible prediction problems [#108][#108]
 
     [#96]: <https://github.com/trane-dev/Trane/pull/96>
     [#98]: <https://github.com/trane-dev/Trane/pull/98>
     [#100]: <https://github.com/trane-dev/Trane/pull/100>
     [#104]: <https://github.com/trane-dev/Trane/pull/104>
+    [#108]: <https://github.com/trane-dev/Trane/pull/108>
 
 v0.4.0 (July 8, 2023)
 =====================

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ v0.5.0 ()
 * Enhancements
     * Add ``ExistsAggregationOp`` [#96][#96]
     * Add `get_aggregation_ops` and `get_filter_ops` functions [#98][#98]
+    * Allow Ops to restrict semantic tags [#108][#108]
 * Fixes
     * Fix FeaturetoolsWrapper class and label times [#100][#100]
     * Fix denormalize to support more than 2 tables [#104][#104]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def make_fake_df():
 @pytest.fixture()
 def make_fake_meta():
     meta = {
-        "id": ("Integer", {"numeric", "index"}),
+        "id": ("Integer", {"numeric", "primary_key"}),
         "date": ("Datetime", {}),
         "state": ("Categorical", {"category"}),
         "amount": ("Double", {"numeric"}),

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -30,7 +30,7 @@ agg_op_str_dict = {
     MinAggregationOp: " the minimum <{}> in all related records",
     MajorityAggregationOp: " the majority <{}> in all related records",
     CountAggregationOp: "the number of records",
-    ExistsAggregationOp: "if there exists a record with",
+    ExistsAggregationOp: "if there exists a record",
 }
 
 filter_op_str_dict = {

--- a/tests/ops/test_op_base.py
+++ b/tests/ops/test_op_base.py
@@ -1,8 +1,12 @@
 import pandas as pd
 import pytest
 
-from trane.ops.aggregation_ops import AvgAggregationOp, MinAggregationOp
-from trane.ops.filter_ops import AllFilterOp, GreaterFilterOp, LessFilterOp
+from trane.ops.aggregation_ops import (
+    AvgAggregationOp,
+    CountAggregationOp,
+    MinAggregationOp,
+)
+from trane.ops.filter_ops import AllFilterOp, EqFilterOp, GreaterFilterOp, LessFilterOp
 
 
 @pytest.fixture
@@ -30,7 +34,29 @@ def test_find_threshold_by_fraction_of_data_to_keep(df):
     # 50 is the lowest number that keeps 25% of the data (length is 7, keep 2 numbers)
     assert best_threshold == 50.0
     assert op.threshold == original_threshold
-    assert hash(op) == hash(("GreaterFilterOp", "col"))
+    assert hash(op) == hash(("GreaterFilterOp", "col", original_threshold))
+
+
+def test_hash_no_threshold():
+    assert hash(CountAggregationOp(None)) == hash(CountAggregationOp(None))
+    assert hash(CountAggregationOp(None)) != hash(CountAggregationOp("col"))
+    assert hash(CountAggregationOp(None)) != hash(EqFilterOp("col"))
+
+
+def test_hash_categorical_threshold():
+    op_1 = EqFilterOp("col")
+    op_1.set_parameters(threshold="NY")
+    op_2 = EqFilterOp("col")
+    op_2.set_parameters(threshold="NJ")
+    assert hash(op_1) != hash(op_2)
+
+
+def test_hash_numeric_threshold():
+    op_1 = GreaterFilterOp("col")
+    op_1.set_parameters(threshold=20.0)
+    op_2 = GreaterFilterOp("col")
+    op_2.set_parameters(threshold=50.0)
+    assert hash(op_1) != hash(op_2)
 
 
 def test_repr():

--- a/tests/ops/test_op_base.py
+++ b/tests/ops/test_op_base.py
@@ -35,7 +35,7 @@ def test_find_threshold_by_fraction_of_data_to_keep(df):
 
 def test_repr():
     assert str(AllFilterOp) == "AllFilterOp"
-    assert AllFilterOp().__repr__() == "AllFilterOp"
+    assert AllFilterOp(None).__repr__() == "AllFilterOp"
     assert GreaterFilterOp("col").__repr__() == "GreaterFilterOp(col)"
     assert GreaterFilterOp("col").__str__() == "GreaterFilterOp(col)"
     assert str(MinAggregationOp("col")) == "MinAggregationOp(col)"

--- a/tests/ops/test_op_base.py
+++ b/tests/ops/test_op_base.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 from trane.ops.aggregation_ops import AvgAggregationOp, MinAggregationOp
-from trane.ops.filter_ops import GreaterFilterOp, LessFilterOp
+from trane.ops.filter_ops import AllFilterOp, GreaterFilterOp, LessFilterOp
 
 
 @pytest.fixture
@@ -31,6 +31,14 @@ def test_find_threshold_by_fraction_of_data_to_keep(df):
     assert best_threshold == 50.0
     assert op.threshold == original_threshold
     assert hash(op) == hash(("GreaterFilterOp", "col"))
+
+
+def test_repr():
+    assert str(AllFilterOp) == "AllFilterOp"
+    assert AllFilterOp().__repr__() == "AllFilterOp"
+    assert GreaterFilterOp("col").__repr__() == "GreaterFilterOp(col)"
+    assert GreaterFilterOp("col").__str__() == "GreaterFilterOp(col)"
+    assert str(MinAggregationOp("col")) == "MinAggregationOp(col)"
 
 
 def test_eq():

--- a/tests/test_prediction_problem.py
+++ b/tests/test_prediction_problem.py
@@ -322,6 +322,8 @@ def verify_problems(problems, df, cutoff_strategy):
             )
             problems_verified += 1
     assert problems_verified >= 35
+    assert problems[0].hash() == problems[0].hash()
+    assert problems[0].hash() != problems[1].hash()
 
 
 def verify_label_times(

--- a/tests/test_prediction_problem.py
+++ b/tests/test_prediction_problem.py
@@ -323,7 +323,7 @@ def verify_problems(problems, df, cutoff_strategy):
             )
             problems_verified += 1
     assert problems_verified >= 35
-    # assert problems[0].__hash__() == problems[0].__hash__()
+    assert problems[0].__hash__() == problems[0].__hash__()
     assert problems[8].__hash__() != problems[9].__hash__()
 
 

--- a/tests/test_prediction_problem.py
+++ b/tests/test_prediction_problem.py
@@ -77,6 +77,7 @@ def verify_problems(problems, df, cutoff_strategy):
     problems_verified = 0
     # bad integration testing
     # not ideal but okay to test for now
+    problems = sorted(problems)
     for p in problems:
         label_times = p.execute(df, -1)
         label_times.rename(columns={"_execute_operations_on_df": "label"}, inplace=True)
@@ -322,8 +323,8 @@ def verify_problems(problems, df, cutoff_strategy):
             )
             problems_verified += 1
     assert problems_verified >= 35
-    assert problems[0].hash() == problems[0].hash()
-    assert problems[0].hash() != problems[1].hash()
+    # assert problems[0].__hash__() == problems[0].__hash__()
+    assert problems[8].__hash__() != problems[9].__hash__()
 
 
 def verify_label_times(

--- a/tests/test_table_meta.py
+++ b/tests/test_table_meta.py
@@ -9,7 +9,7 @@ from trane.typing.logical_types import (
 
 def test_parse_table_meta():
     meta = {
-        "id": ("Categorical", {"index", "category"}),
+        "id": ("Categorical", {"primary_key", "category"}),
         "date": "Datetime",
         "cost": ("Double", {"numeric"}),
         "amount": (None, {"numeric"}),
@@ -17,7 +17,7 @@ def test_parse_table_meta():
     parsed_meta = _parse_table_meta(meta)
     assert parsed_meta["id"] == ColumnSchema(
         logical_type=Categorical,
-        semantic_tags={"index", "category"},
+        semantic_tags={"primary_key", "category"},
     )
     assert parsed_meta["date"] == ColumnSchema(logical_type=Datetime, semantic_tags={})
     assert parsed_meta["cost"] == ColumnSchema(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ import pytest
 
 from trane.core.utils import (
     _check_operations_valid,
-    _extract_exclude_columns,
     _generate_possible_operations,
     _parse_table_meta,
     clean_date,
@@ -226,11 +225,9 @@ def test_generate_possible_operations():
         "department": ("Categorical", {"category"}),
         "user_id": ("Integer", {"numeric", "foreign_key"}),
     }
-    exclude_columns = _extract_exclude_columns(table_meta, "id", "time")
-    assert sorted(exclude_columns) == ["id", "time", "user_id"]
+    table_meta = _parse_table_meta(table_meta)
     possible_operations = _generate_possible_operations(
-        all_columns=table_meta.keys(),
-        exclude_columns=exclude_columns,
+        table_meta=table_meta,
     )
     for filter_op, agg_op in possible_operations:
         assert isinstance(agg_op, AggregationOpBase)
@@ -239,8 +236,8 @@ def test_generate_possible_operations():
             assert agg_op.column_name is None
         if isinstance(filter_op, AllFilterOp):
             assert filter_op.column_name is None
-        assert agg_op.column_name not in exclude_columns
-        assert filter_op.column_name not in exclude_columns
+        assert agg_op.column_name not in ["id", "time", "user_id"]
+        assert filter_op.column_name not in ["id", "time", "user_id"]
 
 
 def test_clean_date():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -226,8 +226,8 @@ def test_generate_possible_operations():
         "department": ("Categorical", {"category"}),
         "user_id": ("Integer", {"numeric", "foreign_key"}),
     }
-    exclude_columns = _extract_exclude_columns(table_meta)
-    assert exclude_columns == ["id", "time", "user_id"]
+    exclude_columns = _extract_exclude_columns(table_meta, "id", "time")
+    assert sorted(exclude_columns) == ["id", "time", "user_id"]
     possible_operations = _generate_possible_operations(
         all_columns=table_meta.keys(),
         exclude_columns=exclude_columns,

--- a/tests/typing/test_inference.py
+++ b/tests/typing/test_inference.py
@@ -1,3 +1,4 @@
+import datetime
 import sys
 
 import numpy as np
@@ -118,12 +119,20 @@ def test_infer_table_meta():
             "a": [1, 2, 3],
             "b": [True, False, True],
             "c": ["a", "b", "c"],
+            "d": [
+                datetime.datetime(2019, 1, 1),
+                datetime.datetime(2019, 1, 2),
+                datetime.datetime(2019, 1, 3),
+            ],
         },
     )
-    table_meta = infer_table_meta(df)
+    table_meta = infer_table_meta(df, entity_col="a", time_col="d")
     for col, column_schema in table_meta.items():
         assert col in df.columns
         assert isinstance(column_schema, ColumnSchema)
     assert table_meta["a"].logical_type == Integer
+    assert table_meta["a"].semantic_tags == {"numeric", "primary_key"}
     assert table_meta["b"].logical_type == Boolean
     assert table_meta["c"].logical_type == Unknown
+    assert table_meta["d"].logical_type == Datetime
+    assert table_meta["d"].semantic_tags == {"time_index"}

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -59,6 +59,9 @@ class PredictionProblem:
             window_size=window_size,
         )
 
+    def __hash__(self) -> int:
+        return hash((self.operations))
+
     def is_valid(self, table_meta=None):
         """
         Typechecking for operations. Insures that their input and output types

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -75,7 +75,7 @@ class PredictionProblem:
         # TODO: why is the opbase hash function not working
         attributes = ()
         for op in self.operations:
-            attributes += (op.column_name, op.threshold)
+            attributes += (type(op), op.column_name, op.threshold)
         return hash(attributes)
 
     def is_valid(self, table_meta=None):

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -59,8 +59,24 @@ class PredictionProblem:
             window_size=window_size,
         )
 
+    def __lt__(self, other):
+        return self.__str__() < (other.__str__())
+
+    def __le__(self, other):
+        return self.__str__() <= (other.__str__())
+
+    def __gt__(self, other):
+        return self.__str__() > (other.__str__())
+
+    def __ge__(self, other):
+        return self.__str__() >= (other.__str__())
+
     def __hash__(self) -> int:
-        return hash(self.operations)
+        # TODO: why is the opbase hash function not working
+        attributes = ()
+        for op in self.operations:
+            attributes += (op.column_name, op.threshold)
+        return hash(attributes)
 
     def is_valid(self, table_meta=None):
         """
@@ -186,7 +202,6 @@ class PredictionProblem:
         for op in self.operations:
             if issubclass(type(op), FilterOpBase):
                 filterop_desc_arr.append(self._describe_filter(op))
-
         # join filter ops with ands and append to the description
         if len(filterop_desc_arr) > 0:
             description += " and ".join(filterop_desc_arr)

--- a/trane/core/prediction_problem.py
+++ b/trane/core/prediction_problem.py
@@ -60,7 +60,7 @@ class PredictionProblem:
         )
 
     def __hash__(self) -> int:
-        return hash((self.operations))
+        return hash(self.operations)
 
     def is_valid(self, table_meta=None):
         """

--- a/trane/core/prediction_problem_generator.py
+++ b/trane/core/prediction_problem_generator.py
@@ -110,7 +110,6 @@ class PredictionProblemGenerator:
             raise ValueError("Must provide a dataframe sample to generate thresholds")
 
         exclude_columns = [self.entity_col, self.time_col]
-        print(exclude_columns)
         problems = []
         possible_operations = _generate_possible_operations(
             table_meta=self.table_meta,

--- a/trane/core/prediction_problem_generator.py
+++ b/trane/core/prediction_problem_generator.py
@@ -4,7 +4,6 @@ from tqdm.notebook import tqdm
 
 from trane.core.prediction_problem import PredictionProblem
 from trane.core.utils import (
-    _extract_exclude_columns,
     _generate_possible_operations,
     _parse_table_meta,
     get_semantic_tags,
@@ -110,16 +109,11 @@ class PredictionProblemGenerator:
         if generate_thresholds and df is None:
             raise ValueError("Must provide a dataframe sample to generate thresholds")
 
-        # a list of problems that will eventually be returned
+        exclude_columns = [self.entity_col, self.time_col]
+        print(exclude_columns)
         problems = []
-
-        exclude_columns = _extract_exclude_columns(
-            self.table_meta,
-            self.entity_col,
-            self.time_col,
-        )
         possible_operations = _generate_possible_operations(
-            all_columns=self.table_meta.keys(),
+            table_meta=self.table_meta,
             exclude_columns=exclude_columns,
         )
 

--- a/trane/core/prediction_problem_generator.py
+++ b/trane/core/prediction_problem_generator.py
@@ -112,7 +112,6 @@ class PredictionProblemGenerator:
 
         # a list of problems that will eventually be returned
         problems = []
-        list(self.table_meta.keys())
 
         exclude_columns = _extract_exclude_columns(
             self.table_meta,

--- a/trane/core/utils.py
+++ b/trane/core/utils.py
@@ -129,8 +129,11 @@ def _generate_possible_operations(
         filter_operations = get_filter_ops()
 
     valid_columns = list(table_meta.keys())
-    if exclude_columns and len(exclude_columns) > 0:
+    if exclude_columns is None:
+        exclude_columns = []
+    elif exclude_columns and len(exclude_columns) > 0:
         valid_columns = [col for col in valid_columns if col not in exclude_columns]
+
     possible_operations = []
     column_pairs = []
     for filter_col, agg_col in itertools.product(

--- a/trane/core/utils.py
+++ b/trane/core/utils.py
@@ -173,6 +173,8 @@ def _generate_possible_operations(
             else:
                 filter_instance = filter_operation(filter_col)
             possible_operations.append((filter_instance, agg_instance))
+    # TODO: why are duplicate problems being generated
+    possible_operations = list(set(possible_operations))
     return possible_operations
 
     # possible_ops = []

--- a/trane/core/utils.py
+++ b/trane/core/utils.py
@@ -1,9 +1,11 @@
+import itertools
 from datetime import datetime
 
 import pandas as pd
 
 from trane.ops.aggregation_ops import AggregationOpBase
 from trane.ops.filter_ops import FilterOpBase
+from trane.ops.utils import get_aggregation_ops, get_filter_ops
 from trane.typing.column_schema import ColumnSchema
 from trane.typing.logical_types import (
     Boolean,
@@ -16,7 +18,8 @@ from trane.typing.logical_types import (
 
 TYPE_MAPPING = {
     "category": ColumnSchema(semantic_tags={"category"}),
-    "index": ColumnSchema(semantic_tags={"index"}),
+    "primary_key": ColumnSchema(semantic_tags={"primary_key"}),
+    "foreign_key": ColumnSchema(semantic_tags={"foreign_key"}),
     "None": ColumnSchema(),
     "numeric": ColumnSchema(semantic_tags={"numeric"}),
     "Categorical": ColumnSchema(logical_type=Categorical, semantic_tags={"category"}),
@@ -62,6 +65,12 @@ def _parse_table_meta(table_meta):
     return parsed_schema
 
 
+def convert_op_type(op_type):
+    if isinstance(op_type, str):
+        return TYPE_MAPPING[op_type]
+    return op_type
+
+
 def _check_operations_valid(
     operations,
     table_meta,
@@ -73,10 +82,8 @@ def _check_operations_valid(
     for op in operations:
         input_output_types = op.input_output_types
         for op_input_type, op_output_type in input_output_types:
-            if isinstance(op_input_type, str):
-                op_input_type = TYPE_MAPPING[op_input_type]
-            if isinstance(op_output_type, str):
-                op_output_type = TYPE_MAPPING[op_output_type]
+            op_input_type = convert_op_type(op_input_type)
+            op_output_type = convert_op_type(op_output_type)
 
             # operation applies to all columns
             if op_input_type == ColumnSchema() and op_input_type.semantic_tags == set():
@@ -107,6 +114,92 @@ def _check_operations_valid(
     return True, table_meta
 
 
+def _extract_exclude_columns(table_meta, entity_col, time_col):
+    exclude_columns = []
+    table_meta = _parse_table_meta(table_meta)
+    for col, column_schema in table_meta.items():
+        if "foreign_key" in column_schema.semantic_tags:
+            exclude_columns.append(col)
+        if "primary_key" in column_schema.semantic_tags:
+            exclude_columns.append(col)
+        if "time_index" in column_schema.semantic_tags:
+            exclude_columns.append(col)
+    exclude_columns.append(entity_col)
+    exclude_columns.append(time_col)
+    return list(set(exclude_columns))
+
+
+def _generate_possible_operations(
+    all_columns,
+    exclude_columns,
+    aggregation_operations=None,
+    filter_operations=None,
+):
+    if aggregation_operations is None:
+        aggregation_operations = get_aggregation_ops()
+    if filter_operations is None:
+        filter_operations = get_filter_ops()
+
+    if not isinstance(all_columns, list):
+        all_columns = list(all_columns)
+
+    valid_columns = [col for col in all_columns if col not in exclude_columns]
+    possible_operations = []
+    column_pairs = []
+    for filter_col, agg_col in itertools.product(
+        valid_columns,
+        valid_columns,
+    ):
+        column_pairs.append((filter_col, agg_col))
+
+    for agg_operation, filter_operation in itertools.product(
+        aggregation_operations,
+        filter_operations,
+    ):
+        for filter_col, agg_col in column_pairs:
+            # not ideal, what if there is more than 1 input type in the op
+            agg_op_input_type = convert_op_type(agg_operation.input_output_types[0][0])
+            filter_op_input_type = convert_op_type(
+                filter_operation.input_output_types[0][0],
+            )
+            agg_instance = None
+            if agg_op_input_type in ["None", None, ColumnSchema()]:
+                agg_instance = agg_operation(None)
+            else:
+                agg_instance = agg_operation(agg_col)
+            filter_instance = None
+            if filter_op_input_type in ["None", None, ColumnSchema()]:
+                filter_instance = filter_operation(None)
+            else:
+                filter_instance = filter_operation(filter_col)
+            possible_operations.append((filter_instance, agg_instance))
+    return possible_operations
+
+    # possible_ops = []
+    # for agg_operation, filter_operation in itertools.product(
+    #     aggregation_operations,
+    #     filter_operations,
+    # ):
+    #     filter_columns = all_columns
+    #     if filter_operation == AllFilterOp:
+    #         filter_columns = [None]
+
+    #     agg_columns = all_columns
+    #     if agg_operation == CountAggregationOp:
+    #         agg_columns = [None]
+    #     for filter_col, agg_col in itertools.product(
+    #         filter_columns,
+    #         agg_columns,
+    #     ):
+    #         if time_col in [filter_col, agg_col]:
+    #             continue
+    #         if entity_col in [filter_col, agg_col]:
+    #             continue
+    #         if filter_col in foregin_keys_columns or agg_col in foregin_keys_columns:
+    #             continue
+    #         possible_ops.append((agg_col, filter_col, agg_operation, filter_operation))
+
+
 def get_semantic_tags(filter_op: FilterOpBase):
     """
     Extract the semantic tags from the filter operation, looking at the input_output_types.
@@ -133,7 +226,7 @@ def check_table_meta(table_meta, entity_col, time_col):
 
     entity_col_type = table_meta[entity_col]
     assert entity_col_type.logical_type in [Integer, Categorical]
-    assert "index" in entity_col_type.semantic_tags
+    assert "primary_key" in entity_col_type.semantic_tags
 
     time_col_type = table_meta[time_col]
     assert time_col_type.logical_type == Datetime

--- a/trane/datasets/load_functions.py
+++ b/trane/datasets/load_functions.py
@@ -51,7 +51,7 @@ def load_covid_metadata():
         ),
         "Country/Region": ColumnSchema(
             logical_type=Categorical,
-            semantic_tags={"category", "index"},
+            semantic_tags={"category", "primary_key"},
         ),
         "Lat": ColumnSchema(logical_type=Double, semantic_tags={"numeric"}),
         "Long": ColumnSchema(logical_type=Double, semantic_tags={"numeric"}),
@@ -68,11 +68,11 @@ def load_youtube_metadata():
         "trending_date": ColumnSchema(logical_type=Datetime),
         "channel_title": ColumnSchema(
             logical_type=Categorical,
-            semantic_tags={"index"},
+            semantic_tags={"primary_key"},
         ),
         "category_id": ColumnSchema(
             logical_type=Categorical,
-            semantic_tags={"category", "index"},
+            semantic_tags={"category", "primary_key"},
         ),
         "views": ColumnSchema(logical_type=Integer, semantic_tags={"numeric"}),
         "likes": ColumnSchema(logical_type=Integer, semantic_tags={"numeric"}),

--- a/trane/ops/aggregation_ops.py
+++ b/trane/ops/aggregation_ops.py
@@ -43,6 +43,7 @@ class CountAggregationOp(AggregationOpBase):
 
     input_output_types = [("None", "Integer")]
     description = " the number of records"
+    restricted_semantic_tags = {"time_index", "primary_key"}
 
     def label_function(self, dataslice):
         return len(dataslice)
@@ -102,6 +103,7 @@ class MajorityAggregationOp(AggregationOpBase):
 class ExistsAggregationOp(AggregationOpBase):
     input_output_types = [("None", "Boolean")]
     description = " if there exists a record"
+    restricted_semantic_tags = {"time_index", "primary_key"}
 
     def label_function(self, dataslice):
         return len(dataslice) > 0

--- a/trane/ops/aggregation_ops.py
+++ b/trane/ops/aggregation_ops.py
@@ -90,7 +90,7 @@ class MinAggregationOp(AggregationOpBase):
 
 class MajorityAggregationOp(AggregationOpBase):
     input_output_types = [("category", "category")]
-    # input_output_types = [("category", "category"), ("index", "index")]
+    # input_output_types = [("category", "category"), ("primary_key", "primary_key")]
     description = " the majority <{}> in all related records"
 
     def label_function(self, dataslice):
@@ -100,8 +100,8 @@ class MajorityAggregationOp(AggregationOpBase):
 
 
 class ExistsAggregationOp(AggregationOpBase):
-    input_output_types = [("None", "Boolean")]
-    description = " if there exists a record with"
+    input_output_types = [("category", "category")]
+    description = " if there exists a record"
 
     def label_function(self, dataslice):
         return len(dataslice) > 0

--- a/trane/ops/filter_ops.py
+++ b/trane/ops/filter_ops.py
@@ -38,7 +38,7 @@ class AllFilterOp(FilterOpBase):
 
 class EqFilterOp(FilterOpBase):
     input_output_types = [("category", "category")]
-    # input_output_types = [("category", "category"), ("index", "index")]
+    # input_output_types = [("category", "category"), ("primary_key", "primary_key")]
     description = "equal to"
 
     def set_parameters(self, threshold: float):
@@ -50,7 +50,7 @@ class EqFilterOp(FilterOpBase):
 
 class NeqFilterOp(FilterOpBase):
     input_output_types = [("category", "category")]
-    # input_output_types = [("category", "category"), ("index", "index")]
+    # input_output_types = [("category", "category"), ("primary_key", "primary_key")]
     description = "not equal to"
 
     def set_parameters(self, threshold: float):

--- a/trane/ops/op_base.py
+++ b/trane/ops/op_base.py
@@ -3,7 +3,12 @@ import pandas as pd
 from trane.ops.threshold_functions import sample_unique_values
 
 
-class OpBase(object):
+class Meta(type):
+    def __repr__(self):
+        return f"{self.__name__}"
+
+
+class OpBase(object, metaclass=Meta):
     """
     Super class of all operations.
     """
@@ -11,7 +16,7 @@ class OpBase(object):
     description = None
     threshold = None
 
-    def __init__(self, column_name, input_type=None, output_type=None):
+    def __init__(self, column_name=None, input_type=None, output_type=None):
         """
         Initalization of all operations.
         Subclasses shouldn't have their own init.
@@ -46,8 +51,10 @@ class OpBase(object):
     def __hash__(self):
         return hash((type(self).__name__, self.column_name))
 
-    def __repr__(self):
-        return type(self).__name__
+    def __repr__(self) -> str:
+        if self.column_name is not None:
+            return "{}({})".format(type(self).__name__, self.column_name)
+        return "{}".format(type(self).__name__)
 
     def __eq__(self, other):
         """Overrides the default implementation"""

--- a/trane/ops/op_base.py
+++ b/trane/ops/op_base.py
@@ -15,8 +15,9 @@ class OpBase(object, metaclass=Meta):
 
     description = None
     threshold = None
+    restricted_semantic_tags = {"time_index", "foreign_key", "primary_key"}
 
-    def __init__(self, column_name=None, input_type=None, output_type=None):
+    def __init__(self, column_name, input_type=None, output_type=None):
         """
         Initalization of all operations.
         Subclasses shouldn't have their own init.

--- a/trane/ops/op_base.py
+++ b/trane/ops/op_base.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import pandas as pd
 
 from trane.ops.threshold_functions import sample_unique_values
@@ -50,7 +52,7 @@ class OpBase(object, metaclass=Meta):
         return (type(self).__name__) >= (type(other).__name__)
 
     def __hash__(self):
-        return hash((type(self).__name__, self.column_name))
+        return hash((type(self).__name__, self.column_name, self.threshold))
 
     def __repr__(self) -> str:
         if self.column_name is not None:
@@ -71,7 +73,7 @@ class OpBase(object, metaclass=Meta):
             return self.description.format(self.column_name)
         return self.description
 
-    def set_parameters(self, threshold: float):
+    def set_parameters(self, threshold: Union[float, str]):
         raise NotImplementedError
 
     def find_threshold_by_fraction_of_data_to_keep(

--- a/trane/parsing/denormalize.py
+++ b/trane/parsing/denormalize.py
@@ -60,7 +60,8 @@ def denormalize(
         flat = flatten_dataframes(parent_table, child_table, parent_key, child_key)
         merged_dataframes[child_table_name] = (flat, original_to_new)
         merged_dataframes[parent_table_name] = (flat, original_to_new)
-
+    # TODO: set primary key to be the index
+    # TODO: pass information to table meta (primary key, foreign keys)? maybe? technically relationships has this info
     return merged_dataframes[target_entity][0]
 
 

--- a/trane/typing/inference.py
+++ b/trane/typing/inference.py
@@ -40,9 +40,17 @@ def _infer_series_schema(series: pd.Series) -> ColumnSchema:
     return ColumnSchema(logical_type=Unknown)
 
 
-def infer_table_meta(df: pd.DataFrame) -> Dict[str, ColumnSchema]:
+def infer_table_meta(
+    df: pd.DataFrame,
+    entity_col=None,
+    time_col=None,
+) -> Dict[str, ColumnSchema]:
     table_meta = {}
     for col in df.columns:
         column_schema = _infer_series_schema(df[col])
         table_meta[col] = column_schema
+    if entity_col:
+        table_meta[entity_col].semantic_tags.add("primary_key")
+    if time_col:
+        table_meta[time_col].semantic_tags.add("time_index")
     return table_meta


### PR DESCRIPTION
- Change "index" to "primary_key"
- Fixes duplicate prediction problem generation by hashing all possible prediction problems
- Allow Ops to restrict semantic tags