### PR TITLE
Control operation combinations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@ v0.6.0 (, 2023)
     * Remove FeaturetoolsWrapper class [#100][#100]
     * Remove covid19 and youtube datasets [#131][#131]
     * Prevent Aggregation operations besides `FirstAggregationOp` and `LastAggregationOp` to be paired with `OrderByOp` [#147][#147]
+    * Prevent `FirstAggregationOp` and `LastAggregationOp` from being paired with `IdentityByOp` (hence only allowing `IdentityByOp`) [#147][#147]
 
     [#124]: <https://github.com/trane-dev/Trane/pull/124>
     [#118]: <https://github.com/trane-dev/Trane/pull/118>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,12 +11,14 @@ v0.6.0 (, 2023)
     * Add Store dataset [#131][#131]
     * Add Order By Operation (OrderByOp, along with IdentityOp and TransformationOpBase) [#138][#138]
     * Add First and Last Aggregation Operations [#144][#144]
+    * Enable operations to exclude other operations they can be applied with [#147][#147]
 * Fixes
     * Rename `_execute_operations_on_df` to `target` in executed prediction problem dataframe [#124][#124]
     * Clean up operation description generation [#118][#118]
     * Remove PredictionProblemEvaluator [#118][#118]
     * Remove FeaturetoolsWrapper class [#100][#100]
     * Remove covid19 and youtube datasets [#131][#131]
+    * Prevent Aggregation operations besides `FirstAggregationOp` and `LastAggregationOp` to be paired with `OrderByOp` [#147][#147]
 
     [#124]: <https://github.com/trane-dev/Trane/pull/124>
     [#118]: <https://github.com/trane-dev/Trane/pull/118>
@@ -25,6 +27,7 @@ v0.6.0 (, 2023)
     [#131]: <https://github.com/trane-dev/Trane/pull/131>
     [#138]: <https://github.com/trane-dev/Trane/pull/138>
     [#144]: <https://github.com/trane-dev/Trane/pull/144>
+    [#147]: <https://github.com/trane-dev/Trane/pull/147>
 
 
 v0.5.0 (July 27, 2023)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -292,9 +292,15 @@ def test_generate_possible_operations():
             assert filter_op.column_name is None
         assert agg_op.column_name not in ["id", "time", "user_id"]
         assert filter_op.column_name not in ["id", "time", "user_id"]
-        assert {filter_op, transform_op, agg_op}.intersection(filter_op.restricted_ops) == set()
-        assert {filter_op, transform_op, agg_op}.intersection(transform_op.restricted_ops) == set()
-        assert {filter_op, transform_op, agg_op}.intersection(agg_op.restricted_ops) == set()
+        assert {filter_op, transform_op, agg_op}.intersection(
+            filter_op.restricted_ops
+        ) == set()
+        assert {filter_op, transform_op, agg_op}.intersection(
+            transform_op.restricted_ops
+        ) == set()
+        assert {filter_op, transform_op, agg_op}.intersection(
+            agg_op.restricted_ops
+        ) == set()
 
 
 def test_clean_date():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -292,6 +292,9 @@ def test_generate_possible_operations():
             assert filter_op.column_name is None
         assert agg_op.column_name not in ["id", "time", "user_id"]
         assert filter_op.column_name not in ["id", "time", "user_id"]
+        assert {filter_op, transform_op, agg_op}.intersection(filter_op.restricted_ops) == set()
+        assert {filter_op, transform_op, agg_op}.intersection(transform_op.restricted_ops) == set()
+        assert {filter_op, transform_op, agg_op}.intersection(agg_op.restricted_ops) == set()
 
 
 def test_clean_date():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -293,19 +293,19 @@ def test_generate_possible_operations():
         assert agg_op.column_name not in ["id", "time", "user_id"]
         assert filter_op.column_name not in ["id", "time", "user_id"]
         assert {
-            filter_op.__name__,
-            transform_op.__name__,
-            agg_op.__name__,
+            filter_op.__class__.__name__,
+            transform_op.__class__.__name__,
+            agg_op.__class__.__name__,
         }.intersection(filter_op.restricted_ops) == set()
         assert {
-            filter_op.__name__,
-            transform_op.__name__,
-            agg_op.__name__,
+            filter_op.__class__.__name__,
+            transform_op.__class__.__name__,
+            agg_op.__class__.__name__,
         }.intersection(transform_op.restricted_ops) == set()
         assert {
-            filter_op.__name__,
-            transform_op.__name__,
-            agg_op.__name__,
+            filter_op.__class__.__name__,
+            transform_op.__class__.__name__,
+            agg_op.__class__.__name__,
         }.intersection(agg_op.restricted_ops) == set()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -292,15 +292,21 @@ def test_generate_possible_operations():
             assert filter_op.column_name is None
         assert agg_op.column_name not in ["id", "time", "user_id"]
         assert filter_op.column_name not in ["id", "time", "user_id"]
-        assert {filter_op, transform_op, agg_op}.intersection(
-            filter_op.restricted_ops
-        ) == set()
-        assert {filter_op, transform_op, agg_op}.intersection(
-            transform_op.restricted_ops
-        ) == set()
-        assert {filter_op, transform_op, agg_op}.intersection(
-            agg_op.restricted_ops
-        ) == set()
+        assert {
+            filter_op.__name__,
+            transform_op.__name__,
+            agg_op.__name__,
+        }.intersection(filter_op.restricted_ops) == set()
+        assert {
+            filter_op.__name__,
+            transform_op.__name__,
+            agg_op.__name__,
+        }.intersection(transform_op.restricted_ops) == set()
+        assert {
+            filter_op.__name__,
+            transform_op.__name__,
+            agg_op.__name__,
+        }.intersection(agg_op.restricted_ops) == set()
 
 
 def test_clean_date():

--- a/trane/core/utils.py
+++ b/trane/core/utils.py
@@ -164,15 +164,20 @@ def _generate_possible_operations(
         transformation_operations,
         filter_operations,
     ):
+        if len({agg_operation, transform_operation, filter_operation}.intersection(
+            agg_operation.restricted_ops.union(
+                transform_operation.restricted_ops.union(
+                    filter_operation.restricted_ops
+                )
+            )
+        )) > 0:
+            # if one of the operations is restricted by another opration, skip
+            continue
         for filter_col, transform_col, agg_col in column_combinations:
             # not ideal, what if there is more than 1 input type in the op
             agg_op_input_type = convert_op_type(agg_operation.input_output_types[0][0])
-            transform_op_input_type = convert_op_type(
-                transform_operation.input_output_types[0][0]
-            )
-            filter_op_input_type = convert_op_type(
-                filter_operation.input_output_types[0][0],
-            )
+            transform_op_input_type = convert_op_type(transform_operation.input_output_types[0][0])
+            filter_op_input_type = convert_op_type(filter_operation.input_output_types[0][0])
             agg_instance = None
             if (
                 len(

--- a/trane/core/utils.py
+++ b/trane/core/utils.py
@@ -166,7 +166,11 @@ def _generate_possible_operations(
     ):
         if (
             len(
-                {agg_operation, transform_operation, filter_operation}.intersection(
+                {
+                    agg_operation.__name__,
+                    transform_operation.__name__,
+                    filter_operation.__name__,
+                }.intersection(
                     agg_operation.restricted_ops.union(
                         transform_operation.restricted_ops.union(
                             filter_operation.restricted_ops

--- a/trane/core/utils.py
+++ b/trane/core/utils.py
@@ -164,20 +164,29 @@ def _generate_possible_operations(
         transformation_operations,
         filter_operations,
     ):
-        if len({agg_operation, transform_operation, filter_operation}.intersection(
-            agg_operation.restricted_ops.union(
-                transform_operation.restricted_ops.union(
-                    filter_operation.restricted_ops
+        if (
+            len(
+                {agg_operation, transform_operation, filter_operation}.intersection(
+                    agg_operation.restricted_ops.union(
+                        transform_operation.restricted_ops.union(
+                            filter_operation.restricted_ops
+                        )
+                    )
                 )
             )
-        )) > 0:
+            > 0
+        ):
             # if one of the operations is restricted by another opration, skip
             continue
         for filter_col, transform_col, agg_col in column_combinations:
             # not ideal, what if there is more than 1 input type in the op
             agg_op_input_type = convert_op_type(agg_operation.input_output_types[0][0])
-            transform_op_input_type = convert_op_type(transform_operation.input_output_types[0][0])
-            filter_op_input_type = convert_op_type(filter_operation.input_output_types[0][0])
+            transform_op_input_type = convert_op_type(
+                transform_operation.input_output_types[0][0]
+            )
+            filter_op_input_type = convert_op_type(
+                filter_operation.input_output_types[0][0]
+            )
             agg_instance = None
             if (
                 len(

--- a/trane/ops/__init__.py
+++ b/trane/ops/__init__.py
@@ -1,3 +1,4 @@
 from trane.ops.op_base import *
 from trane.ops.filter_ops import *
+from trane.ops.transformation_ops import *
 from trane.ops.aggregation_ops import *

--- a/trane/ops/aggregation_ops.py
+++ b/trane/ops/aggregation_ops.py
@@ -140,6 +140,7 @@ class ExistsAggregationOp(AggregationOpBase):
 class FirstAggregationOp(AggregationOpBase):
     input_output_types = [("category", "category")]
     description = " the first <{}> in all related records"
+    restricted_ops = {"IdentityOp"}
 
     def generate_description(self):
         return self.description.format(self.column_name)
@@ -153,6 +154,7 @@ class FirstAggregationOp(AggregationOpBase):
 class LastAggregationOp(AggregationOpBase):
     input_output_types = [("category", "category")]
     description = " the last <{}> in all related records"
+    restricted_ops = {"IdentityOp"}
 
     def generate_description(self):
         return self.description.format(self.column_name)

--- a/trane/ops/op_base.py
+++ b/trane/ops/op_base.py
@@ -18,6 +18,7 @@ class OpBase(object, metaclass=Meta):
     description = None
     threshold = None
     restricted_semantic_tags = {"time_index", "foreign_key", "primary_key"}
+    restricted_ops = set()
 
     def __init__(self, column_name, input_type=None, output_type=None):
         """

--- a/trane/ops/transformation_ops.py
+++ b/trane/ops/transformation_ops.py
@@ -1,8 +1,3 @@
-from trane.ops.aggregation_ops import (
-    AggregationOpBase,
-    FirstAggregationOp,
-    LastAggregationOp,
-)
 from trane.ops.op_base import OpBase
 
 
@@ -32,9 +27,14 @@ class IdentityOp(TransformationOpBase):
 class OrderByOp(TransformationOpBase):
     input_output_types = [("numeric", "Double")]
     description = " sorted by <{}>"
-    restricted_ops = set(AggregationOpBase.__subclasses__()) - {
-        FirstAggregationOp,
-        LastAggregationOp,
+    restricted_ops = {
+        "CountAggregationOp",
+        "SumAggregationOp",
+        "AvgAggregationOp",
+        "MaxAggregationOp",
+        "MinAggregationOp",
+        "MajorityAggregationOp",
+        "ExistsAggregationOp",
     }
 
     def generate_description(self):

--- a/trane/ops/transformation_ops.py
+++ b/trane/ops/transformation_ops.py
@@ -1,5 +1,6 @@
 from trane.ops.op_base import OpBase
 
+from trane.ops.aggregation_ops import AggregationOpBase, FirstAggregationOp, LastAggregationOp
 
 class TransformationOpBase(OpBase):
     """
@@ -27,6 +28,7 @@ class IdentityOp(TransformationOpBase):
 class OrderByOp(TransformationOpBase):
     input_output_types = [("numeric", "Double")]
     description = " sorted by <{}>"
+    restricted_ops = set(AggregationOpBase.__subclasses__()) - {FirstAggregationOp, LastAggregationOp}
 
     def generate_description(self):
         return self.description.format(self.column_name)

--- a/trane/ops/transformation_ops.py
+++ b/trane/ops/transformation_ops.py
@@ -1,6 +1,10 @@
+from trane.ops.aggregation_ops import (
+    AggregationOpBase,
+    FirstAggregationOp,
+    LastAggregationOp,
+)
 from trane.ops.op_base import OpBase
 
-from trane.ops.aggregation_ops import AggregationOpBase, FirstAggregationOp, LastAggregationOp
 
 class TransformationOpBase(OpBase):
     """
@@ -28,7 +32,10 @@ class IdentityOp(TransformationOpBase):
 class OrderByOp(TransformationOpBase):
     input_output_types = [("numeric", "Double")]
     description = " sorted by <{}>"
-    restricted_ops = set(AggregationOpBase.__subclasses__()) - {FirstAggregationOp, LastAggregationOp}
+    restricted_ops = set(AggregationOpBase.__subclasses__()) - {
+        FirstAggregationOp,
+        LastAggregationOp,
+    }
 
     def generate_description(self):
         return self.description.format(self.column_name)


### PR DESCRIPTION
* Enable operations to exclude other operations they can be applied with
* Prevent Aggregation operations besides `FirstAggregationOp` and `LastAggregationOp` to be paired with `OrderByOp` 
* Prevent `FirstAggregationOp` and `LastAggregationOp` from being paired with `IdentityByOp` (hence only allowing `IdentityByOp`)